### PR TITLE
Improve easycast

### DIFF
--- a/Windows/__init__.py
+++ b/Windows/__init__.py
@@ -63,22 +63,18 @@ class EasyCastHandler:
         return self.declared_type.from_param(obj)
 
 EASY_TYPES = [ #obj_type, type_hint, c_func
-    (str, (POINTER(Int16), POINTER(UInt16)), c_wchar_p)
+    # python objects:
+    (str, (POINTER(Int16), POINTER(UInt16)), c_wchar_p),
+    # ctypes objects:
+    (c_wchar_p, (POINTER(Int16), POINTER(UInt16)), None),
+    (c_wchar_p, (POINTER(POINTER(Int16)), POINTER(POINTER(UInt16)))), [pointer]),
 ]
 
-def easytype(obj, type_):
+def easycast(obj, type_):
     for obj_type, type_hint, c_func in EASY_TYPES:
         if isinstance(obj, obj_type) and issubclass(type_, type_hint):
-            return c_func(obj)
-    return obj
-
-def easycast(obj, type_):
-    obj = easytype(obj, type_)
-    if isinstance(obj, c_wchar_p):
-        if issubclass(type_, (POINTER(Int16), POINTER(UInt16))):
+            if c_func is not None: obj = c_func(obj)
             return cast(obj, type_)
-        elif issubclass(type_, (POINTER(POINTER(Int16)), POINTER(POINTER(UInt16)))):
-            return cast(pointer(obj), type_)
     return obj
 
 class Guid(EasyCastStructure):

--- a/Windows/__init__.py
+++ b/Windows/__init__.py
@@ -62,11 +62,19 @@ class EasyCastHandler:
         obj = easycast(obj, self.declared_type)
         return self.declared_type.from_param(obj)
 
+EASY_TYPES = [ #obj_type, type_hint, c_func
+    (str, (POINTER(Int16), POINTER(UInt16)), c_wchar_p)
+]
+
+def easytype(obj, type_):
+    for obj_type, type_hint, c_func in EASY_TYPES:
+        if isinstance(obj, obj_type) and issubclass(type_, type_hint):
+            return c_func(obj)
+    return obj
+
 def easycast(obj, type_):
-    if isinstance(obj, str):
-        if issubclass(type_, (POINTER(Int16), POINTER(UInt16))):
-            return cast(c_wchar_p(obj), type_)
-    elif isinstance(obj, c_wchar_p):
+    obj = easytype(obj, type_)
+    if isinstance(obj, c_wchar_p):
         if issubclass(type_, (POINTER(Int16), POINTER(UInt16))):
             return cast(obj, type_)
         elif issubclass(type_, (POINTER(POINTER(Int16)), POINTER(POINTER(UInt16)))):

--- a/Windows/__init__.py
+++ b/Windows/__init__.py
@@ -67,7 +67,7 @@ EASY_TYPES = [ #obj_type, type_hint, c_func
     (str, (POINTER(Int16), POINTER(UInt16)), c_wchar_p),
     # ctypes objects:
     (c_wchar_p, (POINTER(Int16), POINTER(UInt16)), None),
-    (c_wchar_p, (POINTER(POINTER(Int16)), POINTER(POINTER(UInt16)))), [pointer]),
+    (c_wchar_p, (POINTER(POINTER(Int16)), POINTER(POINTER(UInt16)))), pointer),
 ]
 
 def easycast(obj, type_):


### PR DESCRIPTION
Uses mapping for `easycast` func. so, in future that will be easier to cover more objects from both of python and ctypes.
it hasn't been tested.
