### PR TITLE
Drop head

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -49,6 +49,7 @@ BASE_EXPORTS = [
     "cfunctype",
     "cfunctype_pointer",
     "commethod",
+    "EasyCastMeta",
     "winfunctype",
     "winfunctype_pointer",
 ]

--- a/generate.py
+++ b/generate.py
@@ -40,7 +40,6 @@ BASE_EXPORTS = [
     "SUCCEEDED",
     "Single",
     "String",
-    "String",
     "UInt16",
     "UInt32",
     "UInt64",
@@ -50,7 +49,6 @@ BASE_EXPORTS = [
     "cfunctype",
     "cfunctype_pointer",
     "commethod",
-    "press",
     "winfunctype",
     "winfunctype_pointer",
 ]

--- a/generate.py
+++ b/generate.py
@@ -1348,6 +1348,7 @@ def generate(meta: Metadata) -> None:
             writer.write(pg.emit_header(import_namespaces))
             for td in meta_group_by_namespace:
                 writer.write(pg.emit(td))
+            writer.write("EasyCastMeta.commit(__name__)\n")
 
 
 def generate_one(meta: Metadata, writer: TextIO) -> None:
@@ -1355,6 +1356,7 @@ def generate_one(meta: Metadata, writer: TextIO) -> None:
     writer.write(pg.emit_header_one())
     for td in meta:
         writer.write(pg.emit(td))
+    writer.write("EasyCastMeta.commit(__name__)\n")
 
 
 def xopen(path: str) -> TextIO | lzma.LZMAFile:

--- a/generate.py
+++ b/generate.py
@@ -49,7 +49,6 @@ BASE_EXPORTS = [
     "cfunctype",
     "cfunctype_pointer",
     "commethod",
-    "EasyCastMeta",
     "winfunctype",
     "winfunctype_pointer",
 ]
@@ -1196,7 +1195,6 @@ class PyGenerator:
         writer.write(self.emit_import_ctypes())
         writer.write(self.emit_import_base())
         writer.write(self.emit_import_namespaces(import_namespaces))
-        writer.write(self.emit_getattr())
         return writer.getvalue()
 
     def emit_header_one(self) -> str:
@@ -1204,7 +1202,6 @@ class PyGenerator:
         writer.write(self.emit_import_annotations())
         writer.write(self.emit_import_ctypes())
         writer.write(self.emit_include_base())
-        writer.write(self.emit_getattr())
         return writer.getvalue()
 
     def emit_import_annotations(self) -> str:
@@ -1223,15 +1220,6 @@ class PyGenerator:
         writer = StringIO()
         for namespace in sorted(import_namespaces):
             writer.write(f"import {PACKAGE_NAME}.{namespace}\n")
-        return writer.getvalue()
-
-    def emit_getattr(self) -> str:
-        writer = StringIO()
-        writer.write("import sys\n")
-        writer.write("_parent, _current = __name__.rsplit('.', 1)\n")
-        writer.write("if not hasattr(sys.modules[_parent], _current):\n")
-        writer.write("    setattr(sys.modules[_parent], _current, sys.modules[__name__])\n")
-        writer.write("del _parent, _current\n")
         return writer.getvalue()
 
     def write_architecture_specific_block_if_necessary(
@@ -1360,7 +1348,6 @@ def generate(meta: Metadata) -> None:
             writer.write(pg.emit_header(import_namespaces))
             for td in meta_group_by_namespace:
                 writer.write(pg.emit(td))
-            writer.write("EasyCastMeta.commit(__name__)\n")
 
 
 def generate_one(meta: Metadata, writer: TextIO) -> None:
@@ -1368,7 +1355,6 @@ def generate_one(meta: Metadata, writer: TextIO) -> None:
     writer.write(pg.emit_header_one())
     for td in meta:
         writer.write(pg.emit(td))
-    writer.write("EasyCastMeta.commit(__name__)\n")
 
 
 def xopen(path: str) -> TextIO | lzma.LZMAFile:

--- a/generate.py
+++ b/generate.py
@@ -1196,6 +1196,7 @@ class PyGenerator:
         writer.write(self.emit_import_ctypes())
         writer.write(self.emit_import_base())
         writer.write(self.emit_import_namespaces(import_namespaces))
+        writer.write(self.emit_getattr())
         return writer.getvalue()
 
     def emit_header_one(self) -> str:
@@ -1203,6 +1204,7 @@ class PyGenerator:
         writer.write(self.emit_import_annotations())
         writer.write(self.emit_import_ctypes())
         writer.write(self.emit_include_base())
+        writer.write(self.emit_getattr())
         return writer.getvalue()
 
     def emit_import_annotations(self) -> str:
@@ -1221,6 +1223,15 @@ class PyGenerator:
         writer = StringIO()
         for namespace in sorted(import_namespaces):
             writer.write(f"import {PACKAGE_NAME}.{namespace}\n")
+        return writer.getvalue()
+
+    def emit_getattr(self) -> str:
+        writer = StringIO()
+        writer.write("import sys\n")
+        writer.write("_parent, _current = __name__.rsplit('.', 1)\n")
+        writer.write("if not hasattr(sys.modules[_parent], _current):\n")
+        writer.write("    setattr(sys.modules[_parent], _current, sys.modules[__name__])\n")
+        writer.write("del _parent, _current\n")
         return writer.getvalue()
 
     def write_architecture_specific_block_if_necessary(

--- a/generatert.py
+++ b/generatert.py
@@ -1502,6 +1502,7 @@ class PyGenerator:
         writer.write(self.emit_import_base())
         writer.write(self.emit_import_winrt())
         writer.write(self.emit_import_namespaces(import_namespaces))
+        writer.write(self.emit_getattr())
         return writer.getvalue()
 
     def emit_header_one(self) -> str:
@@ -1510,6 +1511,7 @@ class PyGenerator:
         writer.write(self.emit_import_ctypes())
         writer.write(self.emit_import_typing())
         writer.write(self.emit_include_base())
+        writer.write(self.emit_getattr())
         return writer.getvalue()
 
     def emit_import_annotations(self) -> str:
@@ -1551,6 +1553,15 @@ class PyGenerator:
         writer.write(f"import {PACKAGE_NAME}.Windows.Win32.System.WinRT\n")
         for namespace in sorted(import_namespaces):
             writer.write(f"import {PACKAGE_NAME}.{namespace}\n")
+        return writer.getvalue()
+
+    def emit_getattr(self) -> str:
+        writer = StringIO()
+        writer.write("import sys\n")
+        writer.write("_parent, _current = __name__.rsplit('.', 1)\n")
+        writer.write("if not hasattr(sys.modules[_parent], _current):\n")
+        writer.write("    setattr(sys.modules[_parent], _current, sys.modules[__name__])\n")
+        writer.write("del _parent, _current\n")
         return writer.getvalue()
 
     def write_architecture_specific_block_if_necessary(

--- a/generatert.py
+++ b/generatert.py
@@ -1502,7 +1502,6 @@ class PyGenerator:
         writer.write(self.emit_import_base())
         writer.write(self.emit_import_winrt())
         writer.write(self.emit_import_namespaces(import_namespaces))
-        writer.write(self.emit_getattr())
         return writer.getvalue()
 
     def emit_header_one(self) -> str:
@@ -1511,7 +1510,6 @@ class PyGenerator:
         writer.write(self.emit_import_ctypes())
         writer.write(self.emit_import_typing())
         writer.write(self.emit_include_base())
-        writer.write(self.emit_getattr())
         return writer.getvalue()
 
     def emit_import_annotations(self) -> str:
@@ -1553,15 +1551,6 @@ class PyGenerator:
         writer.write(f"import {PACKAGE_NAME}.Windows.Win32.System.WinRT\n")
         for namespace in sorted(import_namespaces):
             writer.write(f"import {PACKAGE_NAME}.{namespace}\n")
-        return writer.getvalue()
-
-    def emit_getattr(self) -> str:
-        writer = StringIO()
-        writer.write("import sys\n")
-        writer.write("_parent, _current = __name__.rsplit('.', 1)\n")
-        writer.write("if not hasattr(sys.modules[_parent], _current):\n")
-        writer.write("    setattr(sys.modules[_parent], _current, sys.modules[__name__])\n")
-        writer.write("del _parent, _current\n")
         return writer.getvalue()
 
     def write_architecture_specific_block_if_necessary(
@@ -1690,7 +1679,6 @@ def generate(meta: Metadata) -> None:
             writer.write(pg.emit_header(import_namespaces))
             for td in meta_group_by_namespace:
                 writer.write(pg.emit(td))
-            writer.write("EasyCastMeta.commit(__name__)\n")
 
 
 def generate_one(meta: Metadata, writer: TextIO) -> None:
@@ -1698,7 +1686,6 @@ def generate_one(meta: Metadata, writer: TextIO) -> None:
     writer.write(pg.emit_header_one())
     for td in meta:
         writer.write(pg.emit(td))
-    writer.write("EasyCastMeta.commit(__name__)\n")
 
 
 def xopen(path: str) -> TextIO | lzma.LZMAFile:

--- a/generatert.py
+++ b/generatert.py
@@ -1679,6 +1679,7 @@ def generate(meta: Metadata) -> None:
             writer.write(pg.emit_header(import_namespaces))
             for td in meta_group_by_namespace:
                 writer.write(pg.emit(td))
+            writer.write("EasyCastMeta.commit(__name__)\n")
 
 
 def generate_one(meta: Metadata, writer: TextIO) -> None:
@@ -1686,6 +1687,7 @@ def generate_one(meta: Metadata, writer: TextIO) -> None:
     writer.write(pg.emit_header_one())
     for td in meta:
         writer.write(pg.emit(td))
+    writer.write("EasyCastMeta.commit(__name__)\n")
 
 
 def xopen(path: str) -> TextIO | lzma.LZMAFile:

--- a/generatert.py
+++ b/generatert.py
@@ -48,7 +48,6 @@ BASE_EXPORTS = [
     "commethod",
     "cfunctype_pointer",
     "winfunctype_pointer",
-    "press",
     "EasyCastStructure",
     "EasyCastUnion",
     "ComPtr",

--- a/win32more/__init__.py
+++ b/win32more/__init__.py
@@ -153,20 +153,20 @@ class EasyCastMeta(type(Structure), type(Union)):
     def commit(cls, name):
         for struct in cls.registers[name]:
             hints = {
-                name: _patch_char_p(type_)
-                for name, type_ in get_type_hints(struct).items()
+                hint: _patch_char_p(type_)
+                for hint, type_ in get_type_hints(struct).items()
             }
             anonymous = [
-                name for name in hints.keys()
-                if re.match(r"^Anonymous\d*$", name)
+                hint for hint in hints.keys()
+                if re.match(r"^Anonymous\d*$", hint)
             ]
             if anonymous:
                 struct._anonymous_ = anonymous
 
             struct._fields_ = list(hints.items())
 
-            for name in anonymous:
-                hints.update(hints[name]._hints_)
+            for hint in anonymous:
+                hints.update(hints[hint]._hints_)
             struct._hints_ = hints
 
         del cls.registers[name]

--- a/win32more/__init__.py
+++ b/win32more/__init__.py
@@ -77,6 +77,8 @@ class ComPtrMeta(type(c_void_p)):
         if "_ComPtrMeta" in attrs:
             return
 
+        ComPtrMeta.registers[cls.__module__].append(cls)
+
     @classmethod
     def commit(cls, name):
         for struct in cls.registers[name]:
@@ -145,7 +147,7 @@ class EasyCastMeta(type(Structure), type(Union)):
         if "_fields_" in dir(cls):
             return
 
-        registers[cls.__module__].append(cls)
+        EasyCastMeta.registers[cls.__module__].append(cls)
 
     @classmethod
     def commit(cls, name):

--- a/win32more/__init__.py
+++ b/win32more/__init__.py
@@ -239,7 +239,12 @@ def get_hints(struct):
     for hint, type_ in get_type_hints(struct).items():
         type_ = _patch_char_p(type_)
         if not hasattr(type_, '__done_ctypes__'):
-            if issubclass(type_, (EasyCastStructure, EasyCastUnion)):
+            if isinstance(type_, BaseFuncType):
+                if not hasattr(type_, '__done_ctypes__'):
+                    type_.__done_ctypes__ = True
+                    BaseFuncType.commit(type_)
+                type_ = type_._fn
+            elif issubclass(type_, (EasyCastStructure, EasyCastUnion)):
                 EasyCastMeta.commit(type_)
             elif issubclass(type_, ComPtr):
                 ComPtr.commit(type_)

--- a/win32more/__init__.py
+++ b/win32more/__init__.py
@@ -85,7 +85,7 @@ class ComPtrMeta(type(c_void_p)):
 
 # FIXME: How to manage com reference count?  ContextManager style?
 class ComPtr(c_void_p, metaclass=ComPtrMeta):
-    _ComPtrMeta
+    _ComPtrMeta = True
 
     def __init__(self, value=None, own=False):
         super().__init__(value)

--- a/win32more/__init__.py
+++ b/win32more/__init__.py
@@ -120,6 +120,11 @@ class EasyCastStructure(Structure):
     def __init_subclass__(cls, **kwargs):
         super().__init_subclass__(**kwargs)
 
+        # FIXME: not work for Union.
+        # if hasattr(cls, "_fields_"):
+        if "_fields_" in dir(cls):
+            return
+
         hints = {
             name: _patch_char_p(type_)
             for name, type_ in get_type_hints(cls).items()
@@ -205,6 +210,14 @@ def easycast(obj, type_):
     return obj
 
 
+def get_type_hints(prototype, **kwargs):
+    hints = _get_type_hints(prototype, localns=getattr(prototype, "__dict__", None), **kwargs)
+    for name, type_ in hints.items():
+        if type_ is None.__class__:
+            hints[name] = None
+    return hints
+
+
 class Guid(EasyCastStructure):
     _fields_ = [
         ("Data1", UInt32),
@@ -254,14 +267,6 @@ def SUCCEEDED(hr):
 
 def FAILED(hr):
     return hr < 0
-
-
-def get_type_hints(prototype, **kwargs):
-    hints = _get_type_hints(prototype, localns=getattr(prototype, "__dict__", None), **kwargs)
-    for name, type_ in hints.items():
-        if type_ is None.__class__:
-            hints[name] = None
-    return hints
 
 
 class ForeignFunction:

--- a/win32more/__init__.py
+++ b/win32more/__init__.py
@@ -388,14 +388,12 @@ def commethod(vtbl_index):
 
 def cfunctype_pointer(prototype):
     types = list(get_type_hints(prototype).values())
-
     types = types[-1:] + types[:-1]
     return CFUNCTYPE(*types)
 
 
 def winfunctype_pointer(prototype):
     types = list(get_type_hints(prototype).values())
-
     types = types[-1:] + types[:-1]
     return WINFUNCTYPE(*types)
 

--- a/win32more/__init__.py
+++ b/win32more/__init__.py
@@ -77,10 +77,10 @@ class ComPtrMeta(type(c_void_p)):
 
     @classmethod
     def commit(cls, struct):
-        struct._hints_ = get_hints(struct)
-
-        if struct._hints_["extends"] is None:
+        if struct.__annotations__["extends"] == 'None':
             return
+
+        struct._hints_ = get_hints(struct)
 
         # Generic class have multiple base class (Generic[], ComPtr).
         struct.__bases__ = tuple(

--- a/win32more/__init__.py
+++ b/win32more/__init__.py
@@ -387,15 +387,15 @@ def commethod(vtbl_index):
 
 
 def cfunctype_pointer(prototype):
-    hints = get_type_hints(prototype)
-    types = list(hints.values())
+    types = list(get_type_hints(prototype).values())
+
     types = types[-1:] + types[:-1]
     return CFUNCTYPE(*types)
 
 
 def winfunctype_pointer(prototype):
-    hints = get_type_hints(prototype)
-    types = list(hints.values())
+    types = list(get_type_hints(prototype).values())
+
     types = types[-1:] + types[:-1]
     return WINFUNCTYPE(*types)
 

--- a/win32more/_winrt.py
+++ b/win32more/_winrt.py
@@ -30,6 +30,7 @@ from win32more import (
     Byte,
     Char,
     ComPtr,
+    ComPtrMeta,
     Double,
     Guid,
     Int32,
@@ -454,6 +455,9 @@ def _get_type_signature(cls) -> str:
     elif issubclass(cls, ComPtr) and "_iid_" in cls.__dict__:
         return str(cls._iid_)
     elif issubclass(cls, ComPtr):
+        if not hasattr(cls, '__done_ctypes__'):
+            cls.__done_ctypes__ = True
+            ComPtrMeta.commit(cls)
         default_interface = cls._hints_["default_interface"]
         args = _get_type_signature(default_interface)
         return f"rc({cls._classid_};{args})"


### PR DESCRIPTION
I didn't understand why it is there!?
Perhaps to prevent annotations conflicts? then there is `from __future__ import annotations` for it.
This PR will reduce 5% of `Win32` package size.

## Test Plan
`Win32`: generated and ran imports successfully.
`WinRT`: not tested