### PR TITLE
Drop `*_head` naming for structures.

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -1349,7 +1349,7 @@ def generate(meta: Metadata) -> None:
             writer.write(pg.emit_header(import_namespaces))
             for td in meta_group_by_namespace:
                 writer.write(pg.emit(td))
-            writer.write("make_read(__name__)\n"))
+            writer.write("make_ready(__name__)\n")
 
 
 def generate_one(meta: Metadata, writer: TextIO) -> None:
@@ -1357,7 +1357,7 @@ def generate_one(meta: Metadata, writer: TextIO) -> None:
     writer.write(pg.emit_header_one())
     for td in meta:
         writer.write(pg.emit(td))
-    writer.write("make_read(__name__)\n"))
+    writer.write("make_ready(__name__)\n")
 
 
 def xopen(path: str) -> TextIO | lzma.LZMAFile:

--- a/generate.py
+++ b/generate.py
@@ -49,6 +49,7 @@ BASE_EXPORTS = [
     "cfunctype",
     "cfunctype_pointer",
     "commethod",
+    "EasyCastMeta",
     "winfunctype",
     "winfunctype_pointer",
 ]

--- a/generate.py
+++ b/generate.py
@@ -40,7 +40,6 @@ BASE_EXPORTS = [
     "SUCCEEDED",
     "Single",
     "String",
-    "String",
     "UInt16",
     "UInt32",
     "UInt64",
@@ -50,7 +49,6 @@ BASE_EXPORTS = [
     "cfunctype",
     "cfunctype_pointer",
     "commethod",
-    "press",
     "winfunctype",
     "winfunctype_pointer",
 ]

--- a/generate.py
+++ b/generate.py
@@ -1348,6 +1348,7 @@ def generate(meta: Metadata) -> None:
             writer.write(pg.emit_header(import_namespaces))
             for td in meta_group_by_namespace:
                 writer.write(pg.emit(td))
+            writer.write("EasyCastMeta.commit(__name__)\n")
 
 
 def generate_one(meta: Metadata, writer: TextIO) -> None:
@@ -1355,6 +1356,7 @@ def generate_one(meta: Metadata, writer: TextIO) -> None:
     writer.write(pg.emit_header_one())
     for td in meta:
         writer.write(pg.emit(td))
+    writer.write("EasyCastMeta.commit(__name__)\n")
 
 
 def xopen(path: str) -> TextIO | lzma.LZMAFile:

--- a/generate.py
+++ b/generate.py
@@ -51,6 +51,7 @@ BASE_EXPORTS = [
     "commethod",
     "winfunctype",
     "winfunctype_pointer",
+    "make_ready",
 ]
 BASE_EXPORTS_CSV = ", ".join(BASE_EXPORTS)
 
@@ -1348,6 +1349,7 @@ def generate(meta: Metadata) -> None:
             writer.write(pg.emit_header(import_namespaces))
             for td in meta_group_by_namespace:
                 writer.write(pg.emit(td))
+            writer.write("make_read(__name__)\n"))
 
 
 def generate_one(meta: Metadata, writer: TextIO) -> None:
@@ -1355,6 +1357,7 @@ def generate_one(meta: Metadata, writer: TextIO) -> None:
     writer.write(pg.emit_header_one())
     for td in meta:
         writer.write(pg.emit(td))
+    writer.write("make_read(__name__)\n"))
 
 
 def xopen(path: str) -> TextIO | lzma.LZMAFile:

--- a/generate.py
+++ b/generate.py
@@ -49,7 +49,6 @@ BASE_EXPORTS = [
     "cfunctype",
     "cfunctype_pointer",
     "commethod",
-    "EasyCastMeta",
     "winfunctype",
     "winfunctype_pointer",
 ]
@@ -1196,7 +1195,6 @@ class PyGenerator:
         writer.write(self.emit_import_ctypes())
         writer.write(self.emit_import_base())
         writer.write(self.emit_import_namespaces(import_namespaces))
-        writer.write(self.emit_getattr())
         return writer.getvalue()
 
     def emit_header_one(self) -> str:
@@ -1204,7 +1202,6 @@ class PyGenerator:
         writer.write(self.emit_import_annotations())
         writer.write(self.emit_import_ctypes())
         writer.write(self.emit_include_base())
-        writer.write(self.emit_getattr())
         return writer.getvalue()
 
     def emit_import_annotations(self) -> str:
@@ -1223,15 +1220,6 @@ class PyGenerator:
         writer = StringIO()
         for namespace in sorted(import_namespaces):
             writer.write(f"import {PACKAGE_NAME}.{namespace}\n")
-        return writer.getvalue()
-
-    def emit_getattr(self) -> str:
-        writer = StringIO()
-        writer.write("import sys\n")
-        writer.write("_parent, _current = __name__.rsplit('.', 1)\n")
-        writer.write("if not hasattr(sys.modules[_parent], _current):\n")
-        writer.write("    setattr(sys.modules[_parent], _current, sys.modules[__name__])\n")
-        writer.write("del _parent, _current\n")
         return writer.getvalue()
 
     def write_architecture_specific_block_if_necessary(
@@ -1360,7 +1348,6 @@ def generate(meta: Metadata) -> None:
             writer.write(pg.emit_header(import_namespaces))
             for td in meta_group_by_namespace:
                 writer.write(pg.emit(td))
-            writer.write("EasyCastMeta.commit(__name__)\n")
 
 
 def generate_one(meta: Metadata, writer: TextIO) -> None:
@@ -1368,7 +1355,6 @@ def generate_one(meta: Metadata, writer: TextIO) -> None:
     writer.write(pg.emit_header_one())
     for td in meta:
         writer.write(pg.emit(td))
-    writer.write("EasyCastMeta.commit(__name__)\n")
 
 
 def xopen(path: str) -> TextIO | lzma.LZMAFile:

--- a/generate.py
+++ b/generate.py
@@ -1196,6 +1196,7 @@ class PyGenerator:
         writer.write(self.emit_import_ctypes())
         writer.write(self.emit_import_base())
         writer.write(self.emit_import_namespaces(import_namespaces))
+        writer.write(self.emit_getattr())
         return writer.getvalue()
 
     def emit_header_one(self) -> str:
@@ -1203,6 +1204,7 @@ class PyGenerator:
         writer.write(self.emit_import_annotations())
         writer.write(self.emit_import_ctypes())
         writer.write(self.emit_include_base())
+        writer.write(self.emit_getattr())
         return writer.getvalue()
 
     def emit_import_annotations(self) -> str:
@@ -1221,6 +1223,15 @@ class PyGenerator:
         writer = StringIO()
         for namespace in sorted(import_namespaces):
             writer.write(f"import {PACKAGE_NAME}.{namespace}\n")
+        return writer.getvalue()
+
+    def emit_getattr(self) -> str:
+        writer = StringIO()
+        writer.write("import sys\n")
+        writer.write("_parent, _current = __name__.rsplit('.', 1)\n")
+        writer.write("if not hasattr(sys.modules[_parent], _current):\n")
+        writer.write("    setattr(sys.modules[_parent], _current, sys.modules[__name__])\n")
+        writer.write("del _parent, _current\n")
         return writer.getvalue()
 
     def write_architecture_specific_block_if_necessary(

--- a/generatert.py
+++ b/generatert.py
@@ -1502,6 +1502,7 @@ class PyGenerator:
         writer.write(self.emit_import_base())
         writer.write(self.emit_import_winrt())
         writer.write(self.emit_import_namespaces(import_namespaces))
+        writer.write(self.emit_getattr())
         return writer.getvalue()
 
     def emit_header_one(self) -> str:
@@ -1510,6 +1511,7 @@ class PyGenerator:
         writer.write(self.emit_import_ctypes())
         writer.write(self.emit_import_typing())
         writer.write(self.emit_include_base())
+        writer.write(self.emit_getattr())
         return writer.getvalue()
 
     def emit_import_annotations(self) -> str:
@@ -1551,6 +1553,15 @@ class PyGenerator:
         writer.write(f"import {PACKAGE_NAME}.Windows.Win32.System.WinRT\n")
         for namespace in sorted(import_namespaces):
             writer.write(f"import {PACKAGE_NAME}.{namespace}\n")
+        return writer.getvalue()
+
+    def emit_getattr(self) -> str:
+        writer = StringIO()
+        writer.write("import sys\n")
+        writer.write("_parent, _current = __name__.rsplit('.', 1)\n")
+        writer.write("if not hasattr(sys.modules[_parent], _current):\n")
+        writer.write("    setattr(sys.modules[_parent], _current, sys.modules[__name__])\n")
+        writer.write("del _parent, _current\n")
         return writer.getvalue()
 
     def write_architecture_specific_block_if_necessary(

--- a/generatert.py
+++ b/generatert.py
@@ -1502,7 +1502,6 @@ class PyGenerator:
         writer.write(self.emit_import_base())
         writer.write(self.emit_import_winrt())
         writer.write(self.emit_import_namespaces(import_namespaces))
-        writer.write(self.emit_getattr())
         return writer.getvalue()
 
     def emit_header_one(self) -> str:
@@ -1511,7 +1510,6 @@ class PyGenerator:
         writer.write(self.emit_import_ctypes())
         writer.write(self.emit_import_typing())
         writer.write(self.emit_include_base())
-        writer.write(self.emit_getattr())
         return writer.getvalue()
 
     def emit_import_annotations(self) -> str:
@@ -1553,15 +1551,6 @@ class PyGenerator:
         writer.write(f"import {PACKAGE_NAME}.Windows.Win32.System.WinRT\n")
         for namespace in sorted(import_namespaces):
             writer.write(f"import {PACKAGE_NAME}.{namespace}\n")
-        return writer.getvalue()
-
-    def emit_getattr(self) -> str:
-        writer = StringIO()
-        writer.write("import sys\n")
-        writer.write("_parent, _current = __name__.rsplit('.', 1)\n")
-        writer.write("if not hasattr(sys.modules[_parent], _current):\n")
-        writer.write("    setattr(sys.modules[_parent], _current, sys.modules[__name__])\n")
-        writer.write("del _parent, _current\n")
         return writer.getvalue()
 
     def write_architecture_specific_block_if_necessary(
@@ -1690,7 +1679,6 @@ def generate(meta: Metadata) -> None:
             writer.write(pg.emit_header(import_namespaces))
             for td in meta_group_by_namespace:
                 writer.write(pg.emit(td))
-            writer.write("EasyCastMeta.commit(__name__)\n")
 
 
 def generate_one(meta: Metadata, writer: TextIO) -> None:
@@ -1698,7 +1686,6 @@ def generate_one(meta: Metadata, writer: TextIO) -> None:
     writer.write(pg.emit_header_one())
     for td in meta:
         writer.write(pg.emit(td))
-    writer.write("EasyCastMeta.commit(__name__)\n")
 
 
 def xopen(path: str) -> TextIO | lzma.LZMAFile:

--- a/generatert.py
+++ b/generatert.py
@@ -1679,6 +1679,7 @@ def generate(meta: Metadata) -> None:
             writer.write(pg.emit_header(import_namespaces))
             for td in meta_group_by_namespace:
                 writer.write(pg.emit(td))
+            writer.write("EasyCastMeta.commit(__name__)\n")
 
 
 def generate_one(meta: Metadata, writer: TextIO) -> None:
@@ -1686,6 +1687,7 @@ def generate_one(meta: Metadata, writer: TextIO) -> None:
     writer.write(pg.emit_header_one())
     for td in meta:
         writer.write(pg.emit(td))
+    writer.write("EasyCastMeta.commit(__name__)\n")
 
 
 def xopen(path: str) -> TextIO | lzma.LZMAFile:

--- a/generatert.py
+++ b/generatert.py
@@ -71,6 +71,15 @@ WINRT_EXPORTS_CSV = ", ".join(WINRT_EXPORTS)
 JsonType: TypeAlias = Any
 
 
+def _removeprefix(s, prefix):
+    if sys.version_info < (3, 9):
+        if s.startswith(prefix):
+            return s[len(prefix):]
+        else:
+            return s
+    return s.removeprefix(prefix)
+
+
 class TType:
     def __init__(self, js: JsonType) -> None:
         self.js = js
@@ -1323,11 +1332,11 @@ class PyGenerator:
                 continue
             if "SpecialName" in md.attributes:
                 if md.name.startswith("get_"):
-                    property_name = md.name.removeprefix("get_")
+                    property_name = _removeprefix(md.name, "get_")
                     properties[property_name]["get"] = md.name
                     properties[property_name]["is_static"] = "Static" in md.attributes
                 elif md.name.startswith("put_"):
-                    property_name = md.name.removeprefix("put_")
+                    property_name = _removeprefix(md.name, "put_")
                     properties[property_name]["put"] = md.name
                     properties[property_name]["is_static"] = "Static" in md.attributes
                 elif md.name.startswith("add_"):

--- a/generatert.py
+++ b/generatert.py
@@ -51,6 +51,7 @@ BASE_EXPORTS = [
     "EasyCastStructure",
     "EasyCastUnion",
     "ComPtr",
+    "make_ready",
 ]
 BASE_EXPORTS_CSV = ", ".join(BASE_EXPORTS)
 
@@ -1679,6 +1680,7 @@ def generate(meta: Metadata) -> None:
             writer.write(pg.emit_header(import_namespaces))
             for td in meta_group_by_namespace:
                 writer.write(pg.emit(td))
+            writer.write("make_read(__name__)\n"))
 
 
 def generate_one(meta: Metadata, writer: TextIO) -> None:
@@ -1686,6 +1688,7 @@ def generate_one(meta: Metadata, writer: TextIO) -> None:
     writer.write(pg.emit_header_one())
     for td in meta:
         writer.write(pg.emit(td))
+    writer.write("make_read(__name__)\n"))
 
 
 def xopen(path: str) -> TextIO | lzma.LZMAFile:

--- a/generatert.py
+++ b/generatert.py
@@ -1680,7 +1680,7 @@ def generate(meta: Metadata) -> None:
             writer.write(pg.emit_header(import_namespaces))
             for td in meta_group_by_namespace:
                 writer.write(pg.emit(td))
-            writer.write("make_read(__name__)\n"))
+            writer.write("make_ready(__name__)\n")
 
 
 def generate_one(meta: Metadata, writer: TextIO) -> None:
@@ -1688,7 +1688,7 @@ def generate_one(meta: Metadata, writer: TextIO) -> None:
     writer.write(pg.emit_header_one())
     for td in meta:
         writer.write(pg.emit(td))
-    writer.write("make_read(__name__)\n"))
+    writer.write("make_ready(__name__)\n")
 
 
 def xopen(path: str) -> TextIO | lzma.LZMAFile:

--- a/generatert.py
+++ b/generatert.py
@@ -48,7 +48,6 @@ BASE_EXPORTS = [
     "commethod",
     "cfunctype_pointer",
     "winfunctype_pointer",
-    "press",
     "EasyCastStructure",
     "EasyCastUnion",
     "ComPtr",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "py-win32more"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
     "typing_extensions; python_version < '3.9'",
 ]

--- a/readme.txt
+++ b/readme.txt
@@ -30,6 +30,3 @@ How to get latest metadata:
 > cd winmd-printer
 > dotnet run ..\Microsoft.Windows.SDK.Win32Metadata\Windows.Win32.winmd > ..\Windows.Win32.json
 > cd ..
-
-not maintained.
-not tested.

--- a/win32more/__init__.py
+++ b/win32more/__init__.py
@@ -153,20 +153,20 @@ class EasyCastMeta(type(Structure), type(Union)):
     def commit(cls, name):
         for struct in cls.registers[name]:
             hints = {
-                name: _patch_char_p(type_)
-                for name, type_ in get_type_hints(struct).items()
+                hint: _patch_char_p(type_)
+                for hint, type_ in get_type_hints(struct).items()
             }
             anonymous = [
-                name for name in hints.keys()
-                if re.match(r"^Anonymous\d*$", name)
+                hint for hint in hints.keys()
+                if re.match(r"^Anonymous\d*$", hint)
             ]
             if anonymous:
                 struct._anonymous_ = anonymous
 
             struct._fields_ = list(hints.items())
 
-            for name in anonymous:
-                hints.update(hints[name]._hints_)
+            for hint in anonymous:
+                hints.update(hints[hint]._hints_)
             struct._hints_ = hints
 
         del cls.registers[name]

--- a/win32more/__init__.py
+++ b/win32more/__init__.py
@@ -77,6 +77,8 @@ class ComPtrMeta(type(c_void_p)):
         if "_ComPtrMeta" in attrs:
             return
 
+        ComPtrMeta.registers[cls.__module__].append(cls)
+
     @classmethod
     def commit(cls, name):
         for struct in cls.registers[name]:
@@ -145,7 +147,7 @@ class EasyCastMeta(type(Structure), type(Union)):
         if "_fields_" in dir(cls):
             return
 
-        registers[cls.__module__].append(cls)
+        EasyCastMeta.registers[cls.__module__].append(cls)
 
     @classmethod
     def commit(cls, name):

--- a/win32more/__init__.py
+++ b/win32more/__init__.py
@@ -239,7 +239,12 @@ def get_hints(struct):
     for hint, type_ in get_type_hints(struct).items():
         type_ = _patch_char_p(type_)
         if not hasattr(type_, '__done_ctypes__'):
-            if issubclass(type_, (EasyCastStructure, EasyCastUnion)):
+            if isinstance(type_, BaseFuncType):
+                if not hasattr(type_, '__done_ctypes__'):
+                    type_.__done_ctypes__ = True
+                    BaseFuncType.commit(type_)
+                type_ = type_._fn
+            elif issubclass(type_, (EasyCastStructure, EasyCastUnion)):
                 EasyCastMeta.commit(type_)
             elif issubclass(type_, ComPtr):
                 ComPtr.commit(type_)

--- a/win32more/__init__.py
+++ b/win32more/__init__.py
@@ -85,7 +85,7 @@ class ComPtrMeta(type(c_void_p)):
 
 # FIXME: How to manage com reference count?  ContextManager style?
 class ComPtr(c_void_p, metaclass=ComPtrMeta):
-    _ComPtrMeta
+    _ComPtrMeta = True
 
     def __init__(self, value=None, own=False):
         super().__init__(value)

--- a/win32more/__init__.py
+++ b/win32more/__init__.py
@@ -451,12 +451,13 @@ class GetAttr:
                 f"module '{self._mod}' has no attribute '{name}'"
             ) from None
 
-        prottype.__done_ctypes__ = True
-        if issubclass(type_, (EasyCastStructure, EasyCastUnion, ComPtr)):
-            type_.__commit__()
-
         setattr(self._obj, name, prototype)
         delattr(self._obj, f'_unused_{name}')
+
+        if issubclass(prototype, (EasyCastStructure, EasyCastUnion, ComPtr)):
+            prototype.__done_ctypes__ = True
+            prototype.__commit__()
+
         return prototype
 
 

--- a/win32more/__init__.py
+++ b/win32more/__init__.py
@@ -120,6 +120,11 @@ class EasyCastStructure(Structure):
     def __init_subclass__(cls, **kwargs):
         super().__init_subclass__(**kwargs)
 
+        # FIXME: not work for Union.
+        # if hasattr(cls, "_fields_"):
+        if "_fields_" in dir(cls):
+            return
+
         hints = {
             name: _patch_char_p(type_)
             for name, type_ in get_type_hints(cls).items()
@@ -205,6 +210,14 @@ def easycast(obj, type_):
     return obj
 
 
+def get_type_hints(prototype, **kwargs):
+    hints = _get_type_hints(prototype, localns=getattr(prototype, "__dict__", None), **kwargs)
+    for name, type_ in hints.items():
+        if type_ is None.__class__:
+            hints[name] = None
+    return hints
+
+
 class Guid(EasyCastStructure):
     _fields_ = [
         ("Data1", UInt32),
@@ -254,14 +267,6 @@ def SUCCEEDED(hr):
 
 def FAILED(hr):
     return hr < 0
-
-
-def get_type_hints(prototype, **kwargs):
-    hints = _get_type_hints(prototype, localns=getattr(prototype, "__dict__", None), **kwargs)
-    for name, type_ in hints.items():
-        if type_ is None.__class__:
-            hints[name] = None
-    return hints
 
 
 class ForeignFunction:

--- a/win32more/__init__.py
+++ b/win32more/__init__.py
@@ -122,12 +122,12 @@ def _removesuffix(s, suffix):
 class EasyCastBase:
     @classmethod
     def __commit__(struct):
+        hints = get_hints(struct)
+
         # FIXME: not work for Union.
         # if hasattr(cls, "_fields_"):
         if "_fields_" in dir(struct):
             return
-
-        hints = get_hints(struct)
 
         anonymous = [
             hint for hint in hints.keys()
@@ -232,8 +232,8 @@ def get_hints(struct, patch_return=False):
 
         if isinstance(type_, BaseFuncType):
             if not hasattr(type_, '__done_ctypes__'):
-                type_.__done_ctypes__ = True
                 BaseFuncType.commit(type_)
+                type_.__done_ctypes__ = True
             type_ = type_._fn
         elif issubclass(type_, (EasyCastStructure, EasyCastUnion, ComPtr)):
             type_.__commit__()
@@ -420,8 +420,8 @@ class BaseFuncType:
 
     def __call__(self, *args, **kwargs):
         if not hasattr(self, '__done_ctypes__'):
-            self.__done_ctypes__ = True
             BaseFuncType.commit(self)
+            self.__done_ctypes__ = True
         return self._fn(*args, **kwargs)
 
     @classmethod
@@ -455,8 +455,8 @@ class GetAttr:
         delattr(self._obj, f'_unused_{name}')
 
         if issubclass(prototype, (EasyCastStructure, EasyCastUnion, ComPtr)):
-            prototype.__done_ctypes__ = True
             prototype.__commit__()
+            prototype.__done_ctypes__ = True
 
         return prototype
 

--- a/win32more/__init__.py
+++ b/win32more/__init__.py
@@ -388,14 +388,12 @@ def commethod(vtbl_index):
 
 def cfunctype_pointer(prototype):
     types = list(get_type_hints(prototype).values())
-
     types = types[-1:] + types[:-1]
     return CFUNCTYPE(*types)
 
 
 def winfunctype_pointer(prototype):
     types = list(get_type_hints(prototype).values())
-
     types = types[-1:] + types[:-1]
     return WINFUNCTYPE(*types)
 

--- a/win32more/__init__.py
+++ b/win32more/__init__.py
@@ -77,10 +77,10 @@ class ComPtrMeta(type(c_void_p)):
 
     @classmethod
     def commit(cls, struct):
-        struct._hints_ = get_hints(struct)
-
-        if struct._hints_["extends"] is None:
+        if struct.__annotations__["extends"] == 'None':
             return
+
+        struct._hints_ = get_hints(struct)
 
         # Generic class have multiple base class (Generic[], ComPtr).
         struct.__bases__ = tuple(

--- a/win32more/__init__.py
+++ b/win32more/__init__.py
@@ -387,15 +387,15 @@ def commethod(vtbl_index):
 
 
 def cfunctype_pointer(prototype):
-    hints = get_type_hints(prototype)
-    types = list(hints.values())
+    types = list(get_type_hints(prototype).values())
+
     types = types[-1:] + types[:-1]
     return CFUNCTYPE(*types)
 
 
 def winfunctype_pointer(prototype):
-    hints = get_type_hints(prototype)
-    types = list(hints.values())
+    types = list(get_type_hints(prototype).values())
+
     types = types[-1:] + types[:-1]
     return WINFUNCTYPE(*types)
 

--- a/win32more/_winrt.py
+++ b/win32more/_winrt.py
@@ -30,6 +30,7 @@ from win32more import (
     Byte,
     Char,
     ComPtr,
+    ComPtrMeta,
     Double,
     Guid,
     Int32,
@@ -454,6 +455,9 @@ def _get_type_signature(cls) -> str:
     elif issubclass(cls, ComPtr) and "_iid_" in cls.__dict__:
         return str(cls._iid_)
     elif issubclass(cls, ComPtr):
+        if not hasattr(cls, '__done_ctypes__'):
+            cls.__done_ctypes__ = True
+            ComPtrMeta.commit(cls)
         default_interface = cls._hints_["default_interface"]
         args = _get_type_signature(default_interface)
         return f"rc({cls._classid_};{args})"

--- a/win32more/_winrt.py
+++ b/win32more/_winrt.py
@@ -454,7 +454,8 @@ def _get_type_signature(cls) -> str:
     elif issubclass(cls, ComPtr) and "_iid_" in cls.__dict__:
         return str(cls._iid_)
     elif issubclass(cls, ComPtr):
-        cls.__commit__()
+        if getattr(cls, '__commit__', None):
+            cls = cls.__commit__()
         default_interface = cls._hints_["default_interface"]
         args = _get_type_signature(default_interface)
         return f"rc({cls._classid_};{args})"

--- a/win32more/_winrt.py
+++ b/win32more/_winrt.py
@@ -455,8 +455,8 @@ def _get_type_signature(cls) -> str:
         return str(cls._iid_)
     elif issubclass(cls, ComPtr):
         if not hasattr(cls, '__done_ctypes__'):
-            cls.__done_ctypes__ = True
             cls.__commit__()
+            cls.__done_ctypes__ = True
         default_interface = cls._hints_["default_interface"]
         args = _get_type_signature(default_interface)
         return f"rc({cls._classid_};{args})"

--- a/win32more/_winrt.py
+++ b/win32more/_winrt.py
@@ -30,7 +30,6 @@ from win32more import (
     Byte,
     Char,
     ComPtr,
-    ComPtrMeta,
     Double,
     Guid,
     Int32,
@@ -457,7 +456,7 @@ def _get_type_signature(cls) -> str:
     elif issubclass(cls, ComPtr):
         if not hasattr(cls, '__done_ctypes__'):
             cls.__done_ctypes__ = True
-            ComPtrMeta.commit(cls)
+            cls.__commit__()
         default_interface = cls._hints_["default_interface"]
         args = _get_type_signature(default_interface)
         return f"rc({cls._classid_};{args})"

--- a/win32more/_winrt.py
+++ b/win32more/_winrt.py
@@ -454,9 +454,7 @@ def _get_type_signature(cls) -> str:
     elif issubclass(cls, ComPtr) and "_iid_" in cls.__dict__:
         return str(cls._iid_)
     elif issubclass(cls, ComPtr):
-        if not hasattr(cls, '__done_ctypes__'):
-            cls.__commit__()
-            cls.__done_ctypes__ = True
+        cls.__commit__()
         default_interface = cls._hints_["default_interface"]
         args = _get_type_signature(default_interface)
         return f"rc({cls._classid_};{args})"


### PR DESCRIPTION
continued from https://github.com/ynkdir/py-win32more/pull/15 but without metaclasses!

main motivation is code readability. (e.g. in vscode go-to-definition is disabled on `*_head` annotations.)
