### PR TITLE
Add Update SDK workflow

### DIFF
--- a/.github/workflows/update_sdk.yml
+++ b/.github/workflows/update_sdk.yml
@@ -1,0 +1,132 @@
+name: Update SDK
+
+on:
+  schedule:
+    - cron: "0 * * * *" # Run each hour
+  workflow_dispatch:
+
+jobs:
+  update-sdk:
+    name: "Update ${{ matrix.sdk.commit_message }}"
+    runs-on: windows-latest
+
+    strategy:
+      matrix:
+        sdk:
+          - name: "Microsoft.WindowsAppSDK"
+            commit_message: "Windows App SDK"
+            allow_prerelease: false
+            script_file_name: "scripts\\get_appsdk.ps1"
+            json_file_name: "WindowsAppSDK.json"
+          - name: "Microsoft.Web.WebView2"
+            commit_message: "Microsoft.Web.WebView2"
+            allow_prerelease: false
+            script_file_name: "scripts\\get_appsdk.ps1"
+            json_file_name: "WindowsAppSDK.json"
+          - name: "Microsoft.Windows.SDK.Win32Metadata"
+            commit_message: "Win32Metadata"
+            allow_prerelease: true
+            script_file_name: "scripts\\get_win32.ps1"
+            json_file_name: "Windows.Win32.json"
+          - name: "Microsoft.Windows.SDK.Contracts"
+            commit_message: "Windows SDK"
+            allow_prerelease: true
+            script_file_name: "scripts\\get_winrt.ps1"
+            json_file_name: "WindowsSDK.json.xz"
+
+    steps:
+    - name: Checkout win32more code
+      uses: actions/checkout@v4
+      with:
+        ref: ${{ github.event.repository.default_branch }}
+        path: win32more
+
+    - name: Find latest version
+      run: |
+        $packageName = "${{ matrix.sdk.name }}".ToLower()
+        $uri = "https://api.nuget.org/v3-flatcontainer/$packageName/index.json"
+        $response = Invoke-RestMethod -Uri $uri
+        if ($${{ matrix.sdk.allow_prerelease}}) {
+          $versions = $response.versions
+        } else {
+          $versions = $response.versions | Where-Object { $_ -notmatch "-" }
+        }
+        if ($versions.Count -eq 0) {
+            throw "No versions found."
+        }
+        $latestVersion = $versions[-1]
+        $latestVersion = $latestVersion -replace '-preview$', ''
+        echo "latestVersion=$latestVersion" >> $env:GITHUB_ENV
+
+    - name: Verify if there is an update
+      id: is-there-update
+      run: |
+        $jsonPath = "win32generator\resources\metadata\versions.json"
+        $jsonContent = Get-Content -Path $jsonPath -Raw | ConvertFrom-Json
+        $version = $jsonContent."${{ matrix.sdk.name }}"
+        if ([System.Version]$env:latestVersion -le [System.Version]$version) {
+          Write-Output "There isn't any new version of ${{ matrix.sdk.name }}."
+          echo "isSuccess=false" >> $env:GITHUB_OUTPUT
+        } else {
+          echo "isSuccess=true" >> $env:GITHUB_OUTPUT
+        }
+      working-directory: win32more
+
+    - name: Checkout winmd-printer code
+      if: ${{ steps.is-there-update.outputs.isSuccess == 'true' }}
+      uses: actions/checkout@v4
+      with:
+        repository: ynkdir/winmd-printer
+        path: winmd-printer
+
+    - name: Setup .NET
+      if: ${{ steps.is-there-update.outputs.isSuccess == 'true' }}
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: 8.x
+
+    - name: Setup Python
+      if: ${{ steps.is-there-update.outputs.isSuccess == 'true' }}
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.13"
+
+    - name: Setup 7-Zip
+      if: ${{ steps.is-there-update.outputs.isSuccess == 'true' }}
+      run: choco install 7zip --yes
+
+    - name: Run ${{ matrix.sdk.script_file_name }}
+      if: ${{ steps.is-there-update.outputs.isSuccess == 'true' }}
+      run: ${{ matrix.sdk.script_file_name }} $env:latestVersion
+      working-directory: winmd-printer
+
+    - name: Compress ${{ matrix.sdk.json_file_name }} with 7-Zip
+      if: ${{ steps.is-there-update.outputs.isSuccess == 'true' }}
+      run: |
+        Remove-Item win32more\win32generator\resources\metadata\${{ matrix.sdk.json_file_name }}.xz
+        7z a -txz win32more\win32generator\resources\metadata\${{ matrix.sdk.json_file_name }}.xz winmd-printer\${{ matrix.sdk.json_file_name }}
+
+    - name: Run win32generator
+      if: ${{ steps.is-there-update.outputs.isSuccess == 'true' }}
+      run: python -m win32generator
+      working-directory: win32more
+
+    - name: Update versions.json
+      if: ${{ steps.is-there-update.outputs.isSuccess == 'true' }}
+      run: |
+        $jsonPath = "win32generator\resources\metadata\versions.json"
+        $jsonContent = Get-Content -Path $jsonPath -Raw | ConvertFrom-Json
+        $jsonContent."${{ matrix.sdk.name }}" = $env:latestVersion
+        $updatedJson = $jsonContent | ConvertTo-Json
+        Set-Content $jsonPath $updatedJson
+      working-directory: win32more
+
+    - name: Commit changes
+      if: ${{ steps.is-there-update.outputs.isSuccess == 'true' }}
+      run: |
+        git config --global user.name "github-actions[bot]"
+        git config --global user.email "github-actions[bot]@users.noreply.github.com"
+        git add .
+        git commit --allow-empty -m "${{ matrix.sdk.commit_message }} $env:latestVersion"
+        git push origin "${{ github.event.repository.default_branch }}"
+      working-directory: win32more

--- a/win32generator/resources/metadata/versions.json
+++ b/win32generator/resources/metadata/versions.json
@@ -1,0 +1,6 @@
+{
+    "Microsoft.WindowsAppSDK": "1.6.240923002",
+    "Microsoft.Web.WebView2": "1.0.2849.39",
+    "Microsoft.Windows.SDK.Win32Metadata": "63.0.31",
+    "Microsoft.Windows.SDK.Contracts": "10.0.26100.1742"
+}


### PR DESCRIPTION
I merged [Add-update-sdk-workflow](https://github.com/moi15moi/py-win32more/tree/Add-update-sdk-workflow) in my main branch, so I could execute the workflow ``Update SDK`` manually (it seems that cron jobs cannot be executed on fork).
Here is the run: https://github.com/moi15moi/py-win32more/actions/runs/11875453218
As you can see, it updated the ``Windows App SDK`` to the version ``1.6.241106002`` (see [this commit](https://github.com/moi15moi/py-win32more/commit/28f212ce885a5df81949ad20bb65c5ca81dce249)), but it is strange because it only has modified the json file and not the actual code, so I'm not sure if there is a problem.