### PR TITLE
Add Windows ARM CI

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -13,9 +13,22 @@ jobs:
 
     strategy:
       matrix:
-        os: [windows-latest]
+        os: ["windows-latest", "windows-11-arm"]
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
-        architecture: ["x86", "x64"]
+        architecture: ["x64", "x86", "arm64"]
+        exclude:
+          - os: "windows-latest"
+            architecture: "arm64"
+          - os: "windows-11-arm"
+            architecture: "x64"
+          - os: "windows-11-arm"
+            architecture: "x86"
+          - os: "windows-11-arm"
+            architecture: "arm64"
+            python-version: "3.9"
+          - os: "windows-11-arm"
+            architecture: "arm64"
+            python-version: "3.10"
 
     steps:
     - name: Checkout code


### PR DESCRIPTION
A arm runner is now available. See: https://github.blog/changelog/2025-04-14-windows-arm64-hosted-runners-now-available-in-public-preview/