### PR TITLE
feat(xaml): add encoding parameter to LoadComponentFromFile method

### DIFF
--- a/src/win32more/appsdk/xaml.py
+++ b/src/win32more/appsdk/xaml.py
@@ -124,8 +124,8 @@ class XamlClass(ComClass, IComponentConnector):
     def GetBindingConnector(self, connectionId, target):
         return self.__component_connector.GetBindingConnector(connectionId, target)
 
-    def LoadComponentFromFile(self, xaml_path):
-        self.LoadComponentFromString(Path(xaml_path).read_text(), xaml_path)
+    def LoadComponentFromFile(self, xaml_path, encoding : str | None = None):
+        self.LoadComponentFromString(Path(xaml_path).read_text(encoding=encoding), xaml_path)
 
     def LoadComponentFromString(self, xaml_str, xaml_path=None):
         self.__component_connector = XamlComponentConnector()


### PR DESCRIPTION
# Add encoding parameter to LoadComponentFromFile method

## Problem

The `LoadComponentFromFile` method in `XamlClass` currently uses the system's default encoding when reading XAML files. This causes issues on systems where the default ANSI encoding differs from the file's actual encoding.

## Solution

Add an optional `encoding` parameter to the `LoadComponentFromFile` method:

```python
def LoadComponentFromFile(self, xaml_path, encoding: str | None = None):
    self.LoadComponentFromString(Path(xaml_path).read_text(encoding=encoding), xaml_path)