### PR TITLE
Added __isub__ and clear methods to event_setter

### DIFF
--- a/packages/core/src/win32more/_winrt.py
+++ b/packages/core/src/win32more/_winrt.py
@@ -58,23 +58,82 @@ logger = logging.getLogger(__name__)
 
 
 class event:
+    """A class used to create/store event_setter objects of a Windows API object."""
+
     def __init__(self, adder, remover):
-        self._adder = adder
-        self._remover = remover
+        # Store only the name of the adders/removers and retrieve the instance method
+        # later. Calling remover directly will throw an exception.
+        self._adder = adder._prototype.__name__
+        self._remover = remover._prototype.__name__
+        self._event_setters = {}
 
     def __get__(self, instance, owner=None):
         if instance is None:
             return self
-        return event_setter(instance, self._adder)
+
+        # Store/retrieve the event setter using the id of the instance.
+        event_setters = self._event_setters
+        key = id(instance)
+        if key not in event_setters.keys():
+            event_setters[key] = event_setter(instance, self._adder, self._remover)
+
+        return event_setters[key]
 
 
 class event_setter:
-    def __init__(self, instance, adder):
+    """A class used to add callbacks to events of a Windows API object.
+
+    Event callbacks are
+        - Added individually using instance.EventName += callback
+        - Removed individually using instance.EventName -= callback
+        - Cleared using instance.EventName.clear()
+    """
+
+    def __init__(self, instance, adder, remover):
         self._instance = instance
         self._adder = adder
+        self._remover = remover
+        self._callbacks = {}
 
     def __iadd__(self, callback):
-        self._adder(self._instance, callback)
+        # An adder is of the form instance.add_EventName(callback) -> token where the
+        # token is used to remove the added callback.
+        adder_method = getattr(self._instance, self._adder)
+        token = adder_method(callback)
+
+        callbacks = self._callbacks
+        callback_id = id(callback)
+
+        if callback_id not in callbacks.keys():
+            callbacks[callback_id] = []
+
+        # Store the token for the callback.
+        callbacks[callback_id].append(token)
+        return self
+
+    def __isub__(self, callback):
+        # Retrieve the token for the callback.
+        callback_id = id(callback)
+        token = self._callbacks[callback_id].pop()
+
+        # A remover is of the form instance.remover_EventName(token) -> None.
+        remover_method = getattr(self._instance, self._remover)
+        remover_method(token)
+
+        if len(self._callbacks[callback_id]) < 1:
+            del self._callbacks[callback_id]
+
+        return self
+
+    def clear(self):
+        """Remove all the callbacks associated to an event of a Windows API object."""
+        for tokens in self._callbacks.values():
+            for token in tokens:
+                # A remover is of the form instance.remover_EventName(token) -> None.
+                remover_method = getattr(self._instance, self._remover)
+                remover_method(token)
+
+        self._callbacks = {}
 
 
 def winrt_easycast(obj, type_):

--- a/tests/test_winrt.py
+++ b/tests/test_winrt.py
@@ -711,13 +711,13 @@ class TestWinrt(unittest.TestCase):
         class IMock:
             _token = -1
 
-            def add_MockEvent(self: IMock, callback: Callable) -> Token:
+            def add_MockEvent(self, callback: Callable) -> Token:
                 cls = type(self)
                 cls._token += 1
                 trace[cls._token] = callback
                 return cls._token
 
-            def remove_MockEvent(self: IMock, token: Token) -> None:
+            def remove_MockEvent(self, token: Token) -> None:
                 del trace[token]
 
         class Mock:

--- a/tests/test_winrt.py
+++ b/tests/test_winrt.py
@@ -4,7 +4,7 @@ import unittest
 from concurrent.futures import Future
 from ctypes import POINTER, cast, pointer
 from pathlib import Path
-from typing import Generic, TypeVar
+from typing import Callable, Generic, TypeVar
 
 from win32more import (
     FAILED,
@@ -37,6 +37,7 @@ from win32more._winrt import (
     event,
     hstr,
     winrt_commethod,
+    winrt_mixinmethod
 )
 from win32more.Windows.Data.Json import JsonObject, JsonValue
 from win32more.Windows.Data.Xml.Dom import XmlDocument
@@ -703,22 +704,69 @@ class TestWinrt(unittest.TestCase):
         unknown = mock.as_(IInspectable)
         self.assertIs(mock, unknown.as_(ISelf).GetSelf())
 
-    def test_classevent_calls_adder_function_as_classmethod(self):
-        class Meta(type):
+    def test_event_setter(self):
+        class Token(int):
             pass
 
-        class Mock(metaclass=Meta):
-            # @classmethod
-            def add_Changed(cls, callback):
-                trace.append(cls)
+        class IMock:
+            _token = -1
 
-            Meta.Changed = event(add_Changed, None)
+            def add_MockEvent(self: IMock, callback: Callable) -> Token:
+                cls = type(self)
+                cls._token += 1
+                trace[cls._token] = callback
+                return cls._token
 
-        trace = []
+            def remove_MockEvent(self: IMock, token: Token) -> None:
+                del trace[token]
 
-        Mock.Changed += lambda: None
+        class Mock:
+            def as_(self, cls):
+                return cls()
 
-        self.assertEqual(trace, [Mock])
+            @winrt_mixinmethod
+            def add_MockEvent(self: IMock, callback: Callable) -> Token: ...
+
+            @winrt_mixinmethod
+            def remove_MockEvent(self: IMock, token: Token) -> None: ...
+
+            MockEvent = event(add_MockEvent, remove_MockEvent)
+
+        trace = {}
+
+        mock = Mock()
+
+        def callback1(sender, args):
+            pass
+
+        def callback2(sender, args):
+            pass
+
+
+        mock.MockEvent += callback1
+
+        self.assertEqual(trace, {0: callback1})
+
+        mock.MockEvent += callback2
+
+        self.assertEqual(trace, {0: callback1, 1: callback2})
+
+        mock.MockEvent += callback1
+        mock.MockEvent += callback2
+
+        self.assertEqual(trace, {0: callback1, 1: callback2, 2: callback1, 3: callback2})
+
+        mock.MockEvent -= callback2
+
+        self.assertEqual(trace, {0: callback1, 1: callback2, 2: callback1})
+
+        mock.MockEvent -= callback2
+
+        self.assertEqual(trace, {0: callback1, 2: callback1})
+
+        mock.MockEvent.clear()
+
+        self.assertEqual(trace, {})
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes the existing `__iadd__` returning `None` and adds `__isub__` and `clear` functionality to `event_setter`