### PR TITLE
Ensure SequenceProtocol methods cast self object to IVector/IVectorView before operation

### DIFF
--- a/packages/core/src/win32more/_winrt.py
+++ b/packages/core/src/win32more/_winrt.py
@@ -677,14 +677,27 @@ class IterableProtocol:
             iterator.MoveNext()
 
 
-class SequenceProtocol:
-    def __class_getitem__(cls, key):
-        return cls
+class SequenceProtocol(Generic[T]):
+    __class_getitem__ = classmethod(generic_class_getitem)
+
+    # IObservableVector implements IVector but does not inherit it.
+    # Ensure interface for protocol.
+    def __ensure_IVectorView(self):
+        from win32more.Windows.Foundation.Collections import IVectorView
+
+        return self.as_(IVectorView[self.__args])
+
+    def __ensure_IVector(self):
+        from win32more.Windows.Foundation.Collections import IVector
+
+        return self.as_(IVector[self.__args])
 
     def __len__(self):
+        self = self.__ensure_IVectorView()
         return self.Size
 
     def __getitem__(self, index):
+        self = self.__ensure_IVectorView()
         if isinstance(index, slice):
             return [self[i] for i in range(*index.indices(len(self)))]
         elif isinstance(index, int):
@@ -697,6 +710,7 @@ class SequenceProtocol:
             raise TypeError(f"list indices must be integers or slices, not {type(index).__name__}")
 
     def __setitem__(self, index, value):
+        self = self.__ensure_IVector()
         if isinstance(index, slice):
             # FIXME:
             lst = [None] * len(self)
@@ -713,6 +727,7 @@ class SequenceProtocol:
             raise TypeError(f"list indices must be integers or slices, not {type(index).__name__}")
 
     def __delitem__(self, index):
+        self = self.__ensure_IVector()
         if index < 0:
             index += len(self)
         if index < 0 or len(self) <= index:

--- a/packages/core/src/win32more/_winrt.py
+++ b/packages/core/src/win32more/_winrt.py
@@ -682,22 +682,25 @@ class SequenceProtocol(Generic[T]):
 
     # IObservableVector implements IVector but does not inherit it.
     # Ensure interface for protocol.
-    def __ensure_IVectorView(self):
-        from win32more.Windows.Foundation.Collections import IVectorView
-
-        return self.as_(IVectorView[self.__args])
-
     def __ensure_IVector(self):
         from win32more.Windows.Foundation.Collections import IVector
 
         return self.as_(IVector[self.__args])
 
+    def __ensure_IVector_or_IVectorView(self):
+        from win32more.Windows.Foundation.Collections import IVector, IVectorView
+
+        r = self.try_as(IVector[self.__args])
+        if r is None:
+            r = self.as_(IVectorView[self.__args])
+        return r
+
     def __len__(self):
-        self = self.__ensure_IVectorView()
+        self = self.__ensure_IVector_or_IVectorView()
         return self.Size
 
     def __getitem__(self, index):
-        self = self.__ensure_IVectorView()
+        self = self.__ensure_IVector_or_IVectorView()
         if isinstance(index, slice):
             return [self[i] for i in range(*index.indices(len(self)))]
         elif isinstance(index, int):

--- a/tests/test_winrt.py
+++ b/tests/test_winrt.py
@@ -69,6 +69,7 @@ from win32more.Windows.Foundation.Collections import (
     IVector,
     IVectorView,
     StringMap,
+    IObservableVector,
 )
 from win32more.Windows.Globalization import Calendar
 from win32more.Windows.Storage import FileIO, PathIO, StorageFile
@@ -1174,6 +1175,12 @@ class TestWinrt(unittest.TestCase):
         self.assertEqual(received, [d, t, d])
         for value, expected in zip(received, [datetime, timedelta, datetime]):
             self.assertIsInstance(value, expected)
+
+    def test_observable_vector_has_sequence_protocol(self):
+        ov = Vector[Int32]([1, 2, 3]).as_(IObservableVector[Int32])
+        self.assertEqual(len(ov), 3)
+        self.assertEqual([v for v in ov], [1, 2, 3])
+
 
 
 if __name__ == "__main__":

--- a/tests/test_winrt.py
+++ b/tests/test_winrt.py
@@ -66,10 +66,10 @@ from win32more.Windows.Foundation.Collections import (
     IIterator,
     IMap,
     IMapView,
+    IObservableVector,
     IVector,
     IVectorView,
     StringMap,
-    IObservableVector,
 )
 from win32more.Windows.Globalization import Calendar
 from win32more.Windows.Storage import FileIO, PathIO, StorageFile
@@ -1180,7 +1180,6 @@ class TestWinrt(unittest.TestCase):
         ov = Vector[Int32]([1, 2, 3]).as_(IObservableVector[Int32])
         self.assertEqual(len(ov), 3)
         self.assertEqual([v for v in ov], [1, 2, 3])
-
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
#210

IObservableVector implements IVector but does not inherit it.